### PR TITLE
chore(deps): update dependabot to track github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request updates the Dependabot configuration to add automated updates for GitHub Actions workflows. This will help keep workflow dependencies up to date more frequently.

Dependabot configuration updates:

* Added a new entry for the `github-actions` package ecosystem in `.github/dependabot.yml`, enabling daily checks for updates to workflow files in `.github/workflows` and setting a limit of 10 open pull requests.